### PR TITLE
Update to 4.23.0; fix test issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <selenium.version>4.22.0</selenium.version>
+    <selenium.version>4.23.0</selenium.version>
     <checkstyle.version>10.15.0</checkstyle.version>
     <spotbugs.version>4.8.4</spotbugs.version>
     <archunit.version>1.3.0</archunit.version>

--- a/src/main/java/org/openqa/selenium/htmlunit/remote/JsonToHtmlUnitWebElementConverter.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/remote/JsonToHtmlUnitWebElementConverter.java
@@ -40,6 +40,7 @@ public class JsonToHtmlUnitWebElementConverter extends JsonToWebElementConverter
             } catch (Exception e) {
                 // nothing to do here
             }
+            return result;
         }
         
         return super.apply(result);

--- a/src/test/java/org/openqa/selenium/htmlunit/remote/HtmlUnitDriverRemoteElementTest.java
+++ b/src/test/java/org/openqa/selenium/htmlunit/remote/HtmlUnitDriverRemoteElementTest.java
@@ -169,7 +169,7 @@ public class HtmlUnitDriverRemoteElementTest extends RemoteWebDriverTestCase {
         assertEquals("Failed getting element rect", HTTP_OK, response.getStatus());
         Map<String, Object> elementRect = extractMap(response);
         assertEquals("Element width", 1256L, elementRect.get("width"));
-        assertEquals("Element height", 72L, elementRect.get("height"));
+        assertEquals("Element height", 54L, elementRect.get("height"));
         assertEquals("Element 'x' position", 5L, elementRect.get("x"));
         assertEquals("Element 'y' position", 5L, elementRect.get("y"));
     }


### PR DESCRIPTION
In this PR, I upgraded the Selenium version to 4.23.0.  
  
In the process of testing this upgrade, I encountered test failures that led to the discovery of a few issues:
* The JSON converter that deserializes web service responses chained to its super-class when it encountered an **Interaction** object instead of returning the object as it should.
* I had failed to add clean-up code to close the browser session at the end of each test.
* The height value for elements changed from `72` to `54`.